### PR TITLE
Update grammar name in fish.cson

### DIFF
--- a/grammars/fish.cson
+++ b/grammars/fish.cson
@@ -4,7 +4,7 @@
 'firstLineMatch': '^#!.*(fish)'
 'foldingStartMarker': '^\\s*(function|while|if|switch|for)\\s.*$'
 'foldingStopMarker': '^\\s*end\\s*$'
-'name': 'fish'
+'name': 'Shell Script (Fish)'
 'patterns': [
   {
     'begin': '"'


### PR DESCRIPTION
Change `fish` to `Shell Script (Fish)` to be consistent with bash's grammar name.
