### PR TITLE
Fix variables highlighting

### DIFF
--- a/grammars/fish.cson
+++ b/grammars/fish.cson
@@ -166,15 +166,15 @@
         'captures':
           '1':
             'name': 'punctuation.definition.variable.fish'
-        'match': '(\\$)(_|argv|history|HOME|PWD|status|USER)'
-        'name': 'variable.other.fixed.fish'
+        'match': '(\\$)_{2,}(fish|FISH)[a-zA-Z_][a-zA-Z0-9_]*'
+        'name': 'variable.other.fish.fish'
       }
       {
         'captures':
           '1':
             'name': 'punctuation.definition.variable.fish'
-        'match': '(\\$)__(fish|FISH)[a-zA-Z_][a-zA-Z0-9_]*'
-        'name': 'variable.other.fish.fish'
+        'match': '(\\$)(_|argv|history|HOME|PWD|status|USER)'
+        'name': 'variable.other.fixed.fish'
       }
       {
         'captures':


### PR DESCRIPTION
Two changes:

1. First tries to match `$__fish...` variables, only then other `$_...`
2. Matches 2 or more underscores between `$` and `fish`. Very helpful in files like __fish_git_prompt.fish that has stuff like 
```fish
printf "%s$format%s" "$___fish_git_prompt_color_prefix" "$___fish_git_prompt_color_prefix_done$c$b$f$r$p$informative_status$___fish_git_prompt_color_suffix" "$___git_ps_color_suffix_done"
```
