### PR TITLE
Updates

### DIFF
--- a/grammars/fish.cson
+++ b/grammars/fish.cson
@@ -40,14 +40,11 @@
     'name': 'string.quoted.single.fish'
     'patterns': [
       {
-        'match': '\\\\\'|\\\\'
+        'match': '\\\\\'|\\\\\\\\'
         'name': 'constant.character.escape.fish'
       }
       {
         'include': '#variable'
-      }
-      {
-        'include': '#escape'
       }
     ]
   }

--- a/grammars/fish.cson
+++ b/grammars/fish.cson
@@ -113,7 +113,7 @@
     'patterns': [
       {
         'comment': 'Single character character escape sequences'
-        'match': '\\\\(a|b|e|f|n|r|t|v|\\s|\\$|\\\\|\\*|\\?|~|\\%|#|(|)|{|}|\\[|\\]|<|>|\\^)'
+        'match': '\\\\(a|b|e|f|n|r|t|v|\\s|\\$|\\\\|\\*|\\?|~|\\%|#|\\(|\\)|{|}|\\[|\\]|<|>|\\^|\'|")'
         'name': 'constant.character.escape.single.fish'
       }
       {

--- a/grammars/fish.cson
+++ b/grammars/fish.cson
@@ -88,7 +88,7 @@
   {
     'captures':
       '1':
-        'name': 'string.other.option.fish'
+        'name': 'constant.other.option.fish'
     'comment': 'Command short/long options'
     'match': '\\s(-{1,2}[a-zA-Z_\\-0-9]+|-\\w)\\b'
   }

--- a/grammars/fish.cson
+++ b/grammars/fish.cson
@@ -43,9 +43,6 @@
         'match': '\\\\\'|\\\\\\\\'
         'name': 'constant.character.escape.fish'
       }
-      {
-        'include': '#variable'
-      }
     ]
   }
   {

--- a/settings/language-fish-shell.cson
+++ b/settings/language-fish-shell.cson
@@ -1,3 +1,5 @@
 '.source.fish':
   'editor':
     'commentStart': '# '
+    'increaseIndentPattern': '^\\s*(function|begin|while|if|else|switch|for|case)'
+    'decreaseIndentPattern': '^\\s*(case|else|end)'


### PR DESCRIPTION
This PR does:
* Change the scope of the options from string to constant (this fixes #1).
  This is inspired by hash arguments in Ruby which have the scope:
  `constant.other.symbol.hashkey.ruby`.

* Fix single quoted string escape pattern.
  The old pattern recognized a single backslash a escape sequence but that's not correct.

* Remove variables from single quoted string patterns.
  Variables aren't substituted in single quoted strings so they shouldn't be highlighted.

* Fix handling of escaped characters (this fixed #8).
  The regex for escaped characters outside of strings was broken in that it:
    * didn't probably escaped the characters `(` and `)` for the regex,
    * didn't include quotes.

* Add indention patterns.
  Atom uses these to automatically adjust the indention level while typing.